### PR TITLE
hotfix: added static volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "5173:5173"
     volumes:
       - ./oops_trap:/app
-      - /app/node_modules
+      - node_modules_frontend:/app/node_modules
     environment:
       - NODE_ENV=development
     depends_on:
@@ -27,7 +27,7 @@ services:
       - postgres
     volumes:
       - ./backend:/app
-      - /app/node_modules
+      - node_modules_backend:/app/node_modules
 
   liquibase:
     build:
@@ -65,3 +65,5 @@ services:
 
 volumes:
   postgres_data:
+  node_modules_frontend:
+  node_modules_backend:


### PR DESCRIPTION
Теперь не будет создаваться 300500 volume при каждом запуске контейнера. Создастся 1 на каждый необходимый сервис и далее будет обновляться, не плодя копии